### PR TITLE
Fix: package error

### DIFF
--- a/genai/aws-gen-ai-kr/20_applications/02_qa_chatbot/01_preprocess_docs/05_0_load_customer_complex_pdf_kr_opensearch.ipynb
+++ b/genai/aws-gen-ai-kr/20_applications/02_qa_chatbot/01_preprocess_docs/05_0_load_customer_complex_pdf_kr_opensearch.ipynb
@@ -34,6 +34,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f1d336de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install torch==2.0.0 torchvision==0.15.1 --extra-index-url https://download.pytorch.org/whl/cu121"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "802b9aa2-a15a-46f5-925d-0f89afb2a611",
    "metadata": {
     "tags": []

--- a/genai/aws-gen-ai-kr/20_applications/02_qa_chatbot/01_preprocess_docs/05_0_load_default_complex_pdf_kr_opensearch.ipynb
+++ b/genai/aws-gen-ai-kr/20_applications/02_qa_chatbot/01_preprocess_docs/05_0_load_default_complex_pdf_kr_opensearch.ipynb
@@ -34,6 +34,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "81b58cb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install torch==2.0.0 torchvision==0.15.1 --extra-index-url https://download.pytorch.org/whl/cu121"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "802b9aa2-a15a-46f5-925d-0f89afb2a611",
    "metadata": {
     "tags": []


### PR DESCRIPTION
## 1/ fix: pytorch version error
### Problem
```
/home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/pypdf/_crypt_providers/_cryptography.py:32: CryptographyDeprecationWarning: ARC4 has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.ARC4 and will be removed from this module in 48.0.0.
  from cryptography.hazmat.primitives.ciphers.algorithms import AES, ARC4
[nltk_data] Downloading package punkt to /home/ec2-user/nltk_data...
[nltk_data]   Unzipping tokenizers/punkt.zip.
[nltk_data] Downloading package averaged_perceptron_tagger to
[nltk_data]     /home/ec2-user/nltk_data...
[nltk_data]   Unzipping taggers/averaged_perceptron_tagger.zip.
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
File <timed exec>:1
...

ImportError: /home/ec2-user/anaconda3/envs/python3/lib/python3.10/site-packages/torch/lib/../../nvidia/cusparse/lib/libcusparse.so.12: symbol __nvJitLinkComplete_12_4, version libnvJitLink.so.12 not defined in file libnvJitLink.so.12 with link time reference
```
![image](https://github.com/user-attachments/assets/81428638-3e99-4438-90af-cece6331d1dd)

### Solution
Add code for installing specific pytorch version (2.0.0) which is compatible with CUDA version
```
pip install torch==2.0.0 torchvision==0.15.1 --extra-index-url https://download.pytorch.org/whl/cu121
```

## 2/ `RequestError: RequestError(400, 'illegal_argument_exception', 'Unknown tokenizer type [nori_tokenizer] for [nori]')`
### Problem
AccessDenied error when adding nori plugin to lambda
https://github.com/aws-samples/multi-modal-chatbot-with-advanced-rag/issues/9

### Solution
https://github.com/aws-samples/multi-modal-chatbot-with-advanced-rag/pull/10